### PR TITLE
Some minor library functions (min, max and map)

### DIFF
--- a/libdeea.deea
+++ b/libdeea.deea
@@ -2,3 +2,8 @@
 (define (square x) (* x x))
 (define (min a b) (if (< a b) a b))
 (define (max a b) (if (> a b) a b))
+
+(define (map f l)
+  (if (eq? nil l)
+      nil
+    (cons (f (first l)) (map f (rest l)))))

--- a/libdeea.deea
+++ b/libdeea.deea
@@ -1,2 +1,4 @@
 (define (abs x) (if (< x 0) (- x) x))
 (define (square x) (* x x))
+(define (min a b) (if (< a b) a b))
+(define (max a b) (if (> a b) a b))


### PR DESCRIPTION
`min` and `max` should support arbitrary number of arguments. But that is not currently possible.
